### PR TITLE
Scheduling, validation, event descriptions

### DIFF
--- a/lib/huginn_agent.rb
+++ b/lib/huginn_agent.rb
@@ -45,6 +45,10 @@ class HuginnAgent
     end
 
     "#{self.to_s}Agent".constantize.class_eval do
+      cannot_be_scheduled!
+    end
+
+    "#{self.to_s}Agent".constantize.class_eval do
       def default_options
         base_agent.default_options
       end

--- a/lib/huginn_agent.rb
+++ b/lib/huginn_agent.rb
@@ -21,6 +21,9 @@ class HuginnAgent
   def self.description
   end
 
+  def self.event_description
+  end
+
   def default_options
     {}
   end
@@ -46,6 +49,11 @@ class HuginnAgent
     the_description = self.description
     "#{self.to_s}Agent".constantize.class_eval do
       description the_description
+    end
+
+    the_event_description = self.event_description
+    "#{self.to_s}Agent".constantize.class_eval do
+      event_description the_event_description
     end
 
     if self.new.respond_to?(:check)

--- a/lib/huginn_agent.rb
+++ b/lib/huginn_agent.rb
@@ -28,19 +28,7 @@ class HuginnAgent
     {}
   end
 
-  def options
-    parent_agent.options
-  end
-
-  def errors
-    parent_agent.errors
-  end
-
   def validate_options
-  end
-
-  def create_event data
-    parent_agent.create_event data
   end
 
   def method_missing(meth, *args, &blk)

--- a/lib/huginn_agent.rb
+++ b/lib/huginn_agent.rb
@@ -44,8 +44,10 @@ class HuginnAgent
       description the_description
     end
 
-    "#{self.to_s}Agent".constantize.class_eval do
-      cannot_be_scheduled!
+    unless self.new.respond_to?(:check)
+      "#{self.to_s}Agent".constantize.class_eval do
+        cannot_be_scheduled!
+      end
     end
 
     "#{self.to_s}Agent".constantize.class_eval do

--- a/lib/huginn_agent.rb
+++ b/lib/huginn_agent.rb
@@ -36,6 +36,10 @@ class HuginnAgent
   def validate_options
   end
 
+  def create_event data
+    parent_agent.create_event data
+  end
+
   def self.emit
     eval "class ::#{self.to_s}Agent < Agent; def base_agent; @base_agent ||= #{self}.new.tap { |a| a.parent_agent = self}; end; end"
 

--- a/lib/huginn_agent.rb
+++ b/lib/huginn_agent.rb
@@ -43,6 +43,10 @@ class HuginnAgent
     parent_agent.create_event data
   end
 
+  def method_missing(meth, *args, &blk)
+    parent_agent.send(meth, *args, &blk)
+  end
+
   def self.emit
     eval "class ::#{self.to_s}Agent < Agent; def base_agent; @base_agent ||= #{self}.new.tap { |a| a.parent_agent = self}; end; end"
 

--- a/lib/huginn_agent.rb
+++ b/lib/huginn_agent.rb
@@ -44,7 +44,11 @@ class HuginnAgent
       description the_description
     end
 
-    unless self.new.respond_to?(:check)
+    if self.new.respond_to?(:check)
+      "#{self.to_s}Agent".constantize.class_eval do
+        default_schedule 'every_1h'
+      end
+    else
       "#{self.to_s}Agent".constantize.class_eval do
         cannot_be_scheduled!
       end

--- a/lib/huginn_agent.rb
+++ b/lib/huginn_agent.rb
@@ -71,6 +71,12 @@ class HuginnAgent
     end
 
     "#{self.to_s}Agent".constantize.class_eval do
+      def working?
+        base_agent.working?
+      end
+    end
+
+    "#{self.to_s}Agent".constantize.class_eval do
       def default_options
         base_agent.default_options
       end

--- a/lib/huginn_agent.rb
+++ b/lib/huginn_agent.rb
@@ -47,6 +47,10 @@ class HuginnAgent
     if self.new.respond_to?(:check)
       "#{self.to_s}Agent".constantize.class_eval do
         default_schedule 'every_1h'
+
+        def check
+          base_agent.check
+        end
       end
     else
       "#{self.to_s}Agent".constantize.class_eval do

--- a/lib/huginn_agent.rb
+++ b/lib/huginn_agent.rb
@@ -28,6 +28,10 @@ class HuginnAgent
     {}
   end
 
+  def working?
+    true
+  end
+
   def validate_options
   end
 

--- a/spec/huginn_agent_spec.rb
+++ b/spec/huginn_agent_spec.rb
@@ -239,6 +239,13 @@ describe HuginnAgent do
   end
 
   describe "working?" do
+
+    it "should default working? to true" do
+      FirstTest.emit
+      agent = FirstTestAgent.new
+      agent.working?.must_equal true
+    end
+
     it "should bind up working?" do
       FirstTest.emit
       agent = FirstTestAgent.new
@@ -246,6 +253,7 @@ describe HuginnAgent do
       agent.base_agent.stubs(:working?).returns expected_result
       agent.working?.must_be_same_as expected_result
     end
+
   end
 
   describe "all of the methods on the base agent that I do not want to bind up manually" do

--- a/spec/huginn_agent_spec.rb
+++ b/spec/huginn_agent_spec.rb
@@ -21,6 +21,15 @@ class Class
       the_value
     end
   end
+
+  def event_description value
+    the_class = class << self; self; end
+    the_value = value
+    the_class.send(:define_method, :the_event_description) do
+      the_value
+    end
+  end
+
 end
 
 class ::Agent
@@ -29,6 +38,8 @@ end
 class FirstTest < HuginnAgent
   def self.description; 'a'; end
 
+  def self.event_description; 't'; end
+
   def default_options
     @default_options ||= Object.new
   end
@@ -36,6 +47,8 @@ end
 
 class SecondTest < HuginnAgent
   def self.description; 'b'; end
+
+  def self.event_description; 'u'; end
 
   def default_options
     @default_options ||= Object.new
@@ -209,6 +222,20 @@ describe HuginnAgent do
       result.must_be_same_as expected_result
     end
 
+  end
+
+  describe "event description" do
+
+    it "should default to nothing" do
+      HuginnAgent.event_description.nil?.must_equal true
+    end
+
+    it "should bind up the event description" do
+      FirstTest.emit
+      FirstTestAgent.the_event_description.must_equal FirstTest.event_description
+      SecondTest.emit
+      SecondTestAgent.the_event_description.must_equal SecondTest.event_description
+    end
   end
 
 end

--- a/spec/huginn_agent_spec.rb
+++ b/spec/huginn_agent_spec.rb
@@ -238,4 +238,14 @@ describe HuginnAgent do
     end
   end
 
+  describe "working?" do
+    it "should bind up working?" do
+      FirstTest.emit
+      agent = FirstTestAgent.new
+      expected_result = Object.new
+      agent.base_agent.stubs(:working?).returns expected_result
+      agent.working?.must_be_same_as expected_result
+    end
+  end
+
 end

--- a/spec/huginn_agent_spec.rb
+++ b/spec/huginn_agent_spec.rb
@@ -248,4 +248,24 @@ describe HuginnAgent do
     end
   end
 
+  describe "all of the methods on the base agent that I do not want to bind up manually" do
+    it "should all of the undefined methods to the parent agent" do
+      FirstTest.emit
+      agent = FirstTestAgent.new
+
+      expected_result = Object.new
+
+      method = :abc
+      input1 = Object.new
+      input2 = Object.new
+      input3 = Object.new
+
+      agent.stubs(method).with(input1, input2, input3).returns expected_result
+
+      result = agent.base_agent.send(method, input1, input2, input3)
+
+      result.must_be_same_as expected_result
+    end
+  end
+
 end

--- a/spec/huginn_agent_spec.rb
+++ b/spec/huginn_agent_spec.rb
@@ -8,6 +8,11 @@ class Class
       the_value
     end
   end
+
+  def cannot_be_scheduled!
+    (class << self; self; end)
+      .send(:define_method, :the_cannot_be_scheduled!) { true }
+  end
 end
 
 class ::Agent
@@ -149,6 +154,14 @@ describe HuginnAgent do
       first_test.base_agent.errors.must_be_same_as errors
     end
 
+  end
+
+  describe "scheduling" do
+    it "should call cannot_be_scheduled! by default" do
+      FirstTest.emit
+      eval(FirstTestAgent.to_s)
+        .the_cannot_be_scheduled!.must_equal true
+    end
   end
 
 end

--- a/spec/huginn_agent_spec.rb
+++ b/spec/huginn_agent_spec.rb
@@ -32,6 +32,9 @@ class SecondTest < HuginnAgent
   def default_options
     @default_options ||= Object.new
   end
+
+  def check
+  end
 end
 
 describe HuginnAgent do
@@ -161,6 +164,12 @@ describe HuginnAgent do
       FirstTest.emit
       eval(FirstTestAgent.to_s)
         .the_cannot_be_scheduled!.must_equal true
+    end
+
+    it "should NOT call cannot_be_scheduled! if a check method is defined" do
+      SecondTest.emit
+      eval(SecondTestAgent.to_s)
+        .respond_to?(:the_cannot_be_scheduled!).must_equal false
     end
   end
 

--- a/spec/huginn_agent_spec.rb
+++ b/spec/huginn_agent_spec.rb
@@ -185,6 +185,15 @@ describe HuginnAgent do
       eval(SecondTestAgent.to_s)
         .the_default_schedule.must_equal 'every_1h'
     end
+
+    it "should bind the check method" do
+      SecondTest.emit
+      expected_result = Object.new
+      base_agent = Struct.new(:check).new expected_result
+      agent = SecondTestAgent.new
+      agent.stubs(:base_agent).returns base_agent
+      agent.check.must_be_same_as expected_result
+    end
   end
 
 end

--- a/spec/huginn_agent_spec.rb
+++ b/spec/huginn_agent_spec.rb
@@ -13,6 +13,14 @@ class Class
     (class << self; self; end)
       .send(:define_method, :the_cannot_be_scheduled!) { true }
   end
+
+  def default_schedule value
+    the_class = class << self; self; end
+    the_value = value
+    the_class.send(:define_method, :the_default_schedule) do
+      the_value
+    end
+  end
 end
 
 class ::Agent
@@ -170,6 +178,12 @@ describe HuginnAgent do
       SecondTest.emit
       eval(SecondTestAgent.to_s)
         .respond_to?(:the_cannot_be_scheduled!).must_equal false
+    end
+
+    it "should have a default schedule of every hour" do
+      SecondTest.emit
+      eval(SecondTestAgent.to_s)
+        .the_default_schedule.must_equal 'every_1h'
     end
   end
 

--- a/spec/huginn_agent_spec.rb
+++ b/spec/huginn_agent_spec.rb
@@ -196,4 +196,19 @@ describe HuginnAgent do
     end
   end
 
+  describe "create_event" do
+
+    it "should bind the create_event method from the actual agent to the base agent" do
+      FirstTest.emit
+      expected_result = Object.new
+      data = Object.new
+      agent = FirstTestAgent.new
+
+      agent.stubs(:create_event).with(data).returns expected_result
+      result = agent.base_agent.create_event(data)
+      result.must_be_same_as expected_result
+    end
+
+  end
+
 end


### PR DESCRIPTION
### Scheduling

So let's say you have an agent that does not define the `check` method.  Then, by default, the agent is not schedulable:

``` ruby
module ProofOfConceptHuginnAgents
  class Sad < HuginnAgent
  end
end
```

![huginn](https://cloud.githubusercontent.com/assets/148768/8893564/a2bab320-335a-11e5-808b-1a9688d4cd2d.png)

But now let's say that the agent has the `check` method defined.  Then:

``` ruby
module ProofOfConceptHuginnAgents
  class Happy < HuginnAgent
    def check
      create_event payload: { message: 'I am happy!' }
    end
end
```

![huginn](https://cloud.githubusercontent.com/assets/148768/8893569/ce26983a-335a-11e5-9eb0-6d8433740a53.png)
### Validation

If you define `validate_options`, it will be used to validate options before saving an agent

``` ruby
module ProofOfConceptHuginnAgents
  class Sad < HuginnAgent
    def validate_options
      errors.add(:base, 'i have to be sad') unless options['sad_state'].to_s.include? 'sad'
    end
  end
end
```

![huginn](https://cloud.githubusercontent.com/assets/148768/8893574/0b086d78-335b-11e5-84af-913e2d566c7d.png)
### Event description

Defining `self.event_description` will provide the markdown message to any consumers of your agent's events:

``` ruby
module ProofOfConceptHuginnAgents
  class Happy < HuginnAgent
    def self.event_description
      <<EOF
## Events

They should look like
{
  message: 'I am happy!'
}
EOF
    end
  end
end
```

![huginn](https://cloud.githubusercontent.com/assets/148768/8893578/5351a978-335b-11e5-8257-fabb083e239d.png)
