### PR TITLE
Receiving events

### DIFF
--- a/lib/huginn_agent/emitter.rb
+++ b/lib/huginn_agent/emitter.rb
@@ -22,7 +22,9 @@ class HuginnAgent
       set_the_default_options
       set_the_validation
 
-      huginn_agent.class_eval { cannot_receive_events! }
+      unless agent.new.respond_to?(:receive)
+        huginn_agent.class_eval { cannot_receive_events! }
+      end
     end
 
     private

--- a/lib/huginn_agent/emitter.rb
+++ b/lib/huginn_agent/emitter.rb
@@ -21,6 +21,8 @@ class HuginnAgent
       set_the_working
       set_the_default_options
       set_the_validation
+
+      huginn_agent.class_eval { cannot_receive_events! }
     end
 
     private

--- a/lib/huginn_agent/emitter.rb
+++ b/lib/huginn_agent/emitter.rb
@@ -24,6 +24,12 @@ class HuginnAgent
 
       unless agent.new.respond_to?(:receive)
         huginn_agent.class_eval { cannot_receive_events! }
+      else
+        huginn_agent.class_eval do
+          def receive events
+            base_agent.receive events
+          end
+        end
       end
     end
 

--- a/lib/huginn_agent/emitter.rb
+++ b/lib/huginn_agent/emitter.rb
@@ -21,16 +21,7 @@ class HuginnAgent
       set_the_working
       set_the_default_options
       set_the_validation
-
-      unless agent.new.respond_to?(:receive)
-        huginn_agent.class_eval { cannot_receive_events! }
-      else
-        huginn_agent.class_eval do
-          def receive events
-            base_agent.receive events
-          end
-        end
-      end
+      set_the_receiving_of_events
     end
 
     private
@@ -94,6 +85,18 @@ AGENT
         def validate_options
           base_agent.validate_options
         end
+      end
+    end
+
+    def set_the_receiving_of_events
+      if agent.new.respond_to?(:receive)
+        huginn_agent.class_eval do
+          def receive events
+            base_agent.receive events
+          end
+        end
+      else
+        huginn_agent.class_eval { cannot_receive_events! }
       end
     end
 

--- a/spec/huginn_agent_spec.rb
+++ b/spec/huginn_agent_spec.rb
@@ -305,6 +305,15 @@ describe HuginnAgent do
           .respond_to?(:the_cannot_receive_events!).must_equal false
       end
 
+      it "should bind the check method" do
+        ThirdTest.emit
+        expected_result, events = Object.new, Object.new
+        base_agent = Object.new.tap { |s| s.stubs(:receive).with(events).returns expected_result }
+        agent = ThirdTestAgent.new
+        agent.stubs(:base_agent).returns base_agent
+        agent.receive(events).must_be_same_as expected_result
+      end
+
     end
 
   end

--- a/spec/huginn_agent_spec.rb
+++ b/spec/huginn_agent_spec.rb
@@ -14,6 +14,11 @@ class Class
       .send(:define_method, :the_cannot_be_scheduled!) { true }
   end
 
+  def cannot_receive_events!
+    (class << self; self; end)
+      .send(:define_method, :the_cannot_receive_events!) { true }
+  end
+
   def default_schedule value
     the_class = class << self; self; end
     the_value = value
@@ -273,6 +278,14 @@ describe HuginnAgent do
       result = agent.base_agent.send(method, input1, input2, input3)
 
       result.must_be_same_as expected_result
+    end
+  end
+
+  describe "receiving events" do
+    it "should call cannot_receive_events! by default" do
+      FirstTest.emit
+      eval(FirstTestAgent.to_s)
+        .the_cannot_receive_events!.must_equal true
     end
   end
 

--- a/spec/huginn_agent_spec.rb
+++ b/spec/huginn_agent_spec.rb
@@ -63,6 +63,13 @@ class SecondTest < HuginnAgent
   end
 end
 
+class ThirdTest < HuginnAgent
+  def self.description; 'c'; end
+
+  def receive
+  end
+end
+
 describe HuginnAgent do
 
   it "should be a class" do
@@ -74,6 +81,7 @@ describe HuginnAgent do
     after do
       Object.send(:remove_const, :FirstTestAgent) if Object.constants.include?(:FirstTestAgent)
       Object.send(:remove_const, :SecondTestAgent) if Object.constants.include?(:FirstTestAgent)
+      Object.send(:remove_const, :ThirdTestAgent) if Object.constants.include?(:FirstTestAgent)
     end
 
     [
@@ -282,11 +290,23 @@ describe HuginnAgent do
   end
 
   describe "receiving events" do
+
     it "should call cannot_receive_events! by default" do
       FirstTest.emit
       eval(FirstTestAgent.to_s)
         .the_cannot_receive_events!.must_equal true
     end
+
+    describe "when receive is declared" do
+
+      it "should not call cannot_receive_events" do
+        ThirdTest.emit
+        eval(ThirdTestAgent.to_s)
+          .respond_to?(:the_cannot_receive_events!).must_equal false
+      end
+
+    end
+
   end
 
 end


### PR DESCRIPTION
So just create an agent that defines `receive` like so:

``` ruby
class Something < HuginnAgent

  def receive events
    puts events.inspect
  end

end
```

And you'll get an agent that can receive events:

![huginn](https://cloud.githubusercontent.com/assets/148768/8898463/276800f2-33ea-11e5-9eca-26dcf23d2fad.png)

If you don't define `receive`, then your agent won't be able to receive events.

![huginn](https://cloud.githubusercontent.com/assets/148768/8898514/db326ed8-33ea-11e5-80a2-9f35064aaff8.png)
